### PR TITLE
Add push count sample support

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.h
@@ -15,6 +15,7 @@
 - (void)fitness_getDailyStepSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_saveSteps:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_saveWalkingRunningDistance:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)fitness_savePushCountSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_initializeStepEventObserver:(NSDictionary *)input hasListeners:(bool)hasListeners callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_getDistanceWalkingRunningOnDay:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_getDailyDistanceWalkingRunningSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -177,6 +177,31 @@
     }];
 }
 
+- (void)fitness_savePushCountSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    double value = [RCTAppleHealthKit doubleFromOptions:input key:@"value" withDefault:(double)0];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+
+    if(startDate == nil || endDate == nil){
+        callback(@[RCTMakeError(@"startDate and endDate are required in options", nil, nil)]);
+        return;
+    }
+
+    HKUnit *unit = [HKUnit countUnit];
+    HKQuantity *quantity = [HKQuantity quantityWithUnit:unit doubleValue:value];
+    HKQuantityType *type = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierPushCount];
+    HKQuantitySample *sample = [HKQuantitySample quantitySampleWithType:type quantity:quantity startDate:startDate endDate:endDate];
+
+    [self.healthStore saveObject:sample withCompletion:^(BOOL success, NSError *error) {
+        if (!success) {
+            callback(@[RCTJSErrorFromNSError(error)]);
+            return;
+        }
+        callback(@[[NSNull null], @(value)]);
+    }];
+}
+
 
 
 - (void)fitness_initializeStepEventObserver:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -277,6 +277,12 @@ RCT_EXPORT_METHOD(saveWalkingRunningDistance:(NSDictionary *)input callback:(RCT
     [self fitness_saveWalkingRunningDistance:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(savePushCountSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self fitness_savePushCountSample:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getDistanceWalkingRunning:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/README.md
+++ b/README.md
@@ -100,12 +100,20 @@ AppleHealthKit.initHealthKit(permissions, (error: string) => {
     startDate: new Date(2020, 1, 1).toISOString(),
   }
 
-  AppleHealthKit.getHeartRateSamples(
+AppleHealthKit.getHeartRateSamples(
     options,
     (callbackError: string, results: HealthValue[]) => {
       /* Samples are now collected from HealthKit */
     },
   )
+})
+```
+
+```ts
+AppleHealthKit.savePushCountSample({
+  value: 30,
+  startDate: new Date().toISOString(),
+  endDate: new Date().toISOString(),
 })
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -170,6 +170,11 @@ declare module 'react-native-health' {
       callback: (error: string, result: HealthValue) => void,
     ): void
 
+    savePushCountSample(
+      options: HealthValueOptions,
+      callback: (error: string, result: HealthValue) => void,
+    ): void
+
     getDistanceWalkingRunning(
       options: HealthInputOptions,
       callback: (err: string, results: HealthValue) => void,
@@ -801,6 +806,7 @@ declare module 'react-native-health' {
     SleepAnalysis = 'SleepAnalysis',
     StepCount = 'StepCount',
     Steps = 'Steps',
+    PushCount = 'PushCount',
     Vo2Max = 'Vo2Max',
     WaistCircumference = 'WaistCircumference',
     WalkingHeartRateAverage = 'WalkingHeartRateAverage',

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ export const HealthKit = {
   getDailyStepCountSamples: AppleHealthKit.getDailyStepCountSamples,
   saveSteps: AppleHealthKit.saveSteps,
   saveWalkingRunningDistance: AppleHealthKit.saveWalkingRunningDistance,
+  savePushCountSample: AppleHealthKit.savePushCountSample,
   getDistanceWalkingRunning: AppleHealthKit.getDistanceWalkingRunning,
   getDailyDistanceWalkingRunningSamples: AppleHealthKit.getDailyDistanceWalkingRunningSamples,
   getDistanceCycling: AppleHealthKit.getDistanceCycling,

--- a/src/constants/Permissions.js
+++ b/src/constants/Permissions.js
@@ -88,6 +88,7 @@ export const Permissions = {
   SleepAnalysis: 'SleepAnalysis',
   StepCount: 'StepCount',
   Steps: 'Steps',
+  PushCount: 'PushCount',
   Vo2Max: 'Vo2Max',
   WaistCircumference: 'WaistCircumference',
   WalkingHeartRateAverage: 'WalkingHeartRateAverage',


### PR DESCRIPTION
## Summary
- add savePushCountSample implementation for iOS
- export savePushCountSample in JS API and typings
- add `PushCount` permission constant
- document push count example in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d52353b448332a3481bcf80b318c0